### PR TITLE
add:門限判定スケジューラの実装

### DIFF
--- a/app/jobs/curfew_job.py
+++ b/app/jobs/curfew_job.py
@@ -1,0 +1,73 @@
+from apscheduler.schedulers.background import BackgroundScheduler
+from datetime import datetime
+from app.database import SessionLocal
+from app.services import db_service, line_message_service
+from app.config import TARGET_ID, LINE_USER_ID
+
+scheduler = BackgroundScheduler()
+
+def check_curfew_job():
+    """
+    門限チェックジョブ
+    """
+    print("=== Checking curfew... ===")
+    db = SessionLocal()
+    try:
+        curfew_time = db_service.get_curfew_time(db, TARGET_ID)
+        print(f"curfew_time from DB: {curfew_time}")
+        if not curfew_time:
+            print("門限未設定、処理終了")
+            return
+
+        now = datetime.now().time()
+        print(f"current time: {now}")
+
+        # 門限超過チェック
+        if now >= curfew_time:
+            print("門限超過判定: True")
+            # 通知対象となる外出レコードを取得
+            access = db_service.get_unalerted_outside_access(db, TARGET_ID)
+            print(f"access fetched: {access}")
+            if access:
+                # LINE通知
+                line_message_service.push_confirm_template(
+                    user_id=LINE_USER_ID,
+                    text="門限を過ぎています。すでに帰宅していますか？"
+                )
+                print(f"[{now}] curfew alert sent for access_id={access.id}")
+
+                # 通知済みに更新
+                db_service.update_has_alerted(db, access.id)
+
+                # awaiting_curfew_time状態に更新
+                db_service.update_awaiting_state(db, access.target_id, state="awaiting_curfew_time")
+                print(f"access_id={access.id} marked as alerted")
+            else:
+                print("通知対象の外出レコードなし")
+        else:
+            print("門限超過判定: False")
+    finally:
+        db.close()
+
+
+def start_scheduler():
+    db = SessionLocal()
+    try:
+        curfew_time: datetime.time = db_service.get_curfew_time(db, TARGET_ID)
+        if not curfew_time:
+            print("curfew_time 未設定")
+            return
+
+        scheduler.add_job(
+            check_curfew_job,
+            "cron",
+            hour=curfew_time.hour,
+            minute=curfew_time.minute,
+            id=f"curfew_job_{TARGET_ID}",
+            replace_existing=True
+        )
+        scheduler.start()
+        print(f"Scheduler started with curfew_time={curfew_time}")
+    finally:
+        db.close()
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,24 @@
 from fastapi import FastAPI
+from contextlib import asynccontextmanager
 from .database import Base, engine
 from app.routers import webhook, accesses, device, messages, targets
+from app.jobs.curfew_job import start_scheduler, scheduler
 
 Base.metadata.create_all(bind=engine)
 
-app = FastAPI()
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # 起動時
+    if not scheduler.running:
+        start_scheduler()
+        print("Scheduler started")
+    yield
+    # 終了時
+    if scheduler.running:
+        scheduler.shutdown(wait=False)
+        print("Scheduler stopped")
+
+app = FastAPI(lifespan=lifespan)
 
 app.include_router(webhook.router)
 app.include_router(accesses.router)

--- a/app/services/db_service.py
+++ b/app/services/db_service.py
@@ -1,5 +1,6 @@
 from sqlalchemy.orm import Session
 from app import models
+from datetime import datetime, time
 
 def create_message(db: Session, target_id: int, text: str):
     """新しいメッセージを作成"""
@@ -10,7 +11,16 @@ def create_message(db: Session, target_id: int, text: str):
     return message
 
 
-def update_curfew(db: Session, target_id: int, time_str: str):
+def get_curfew_time(db: Session, target_id: int) -> time:
+    """門限を取得"""
+    target = db.query(models.Target).filter(models.Target.id == target_id).first()
+    if not target or not target.curfew_time:
+        return None
+
+    return target.curfew_time
+
+
+def update_curfew_time(db: Session, target_id: int, time_str: str):
     """門限を更新（存在しなければ作成）"""
     target = db.query(models.Target).filter(models.Target.id == target_id).first()
     if target:
@@ -22,11 +32,6 @@ def update_curfew(db: Session, target_id: int, time_str: str):
     db.commit()
     db.refresh(target)
     return target
-
-
-def get_curfew(db: Session, target_id: int):
-    """門限を取得"""
-    return db.query(models.Target).filter(models.Target.id == target_id).first().curfew_time
 
 
 def get_awaiting_state(db: Session, target_id: int) -> str | None:
@@ -43,3 +48,54 @@ def update_awaiting_state(db: Session, target_id: int, state: str | None) -> Non
     target.awaiting_state = state
     db.commit()
     db.refresh(target)
+
+
+def update_has_alerted(db: Session, access_id: int) -> None:
+    """対象者の has_alerted を更新"""
+    access = db.query(models.Access).filter(models.Access.id == access_id).first()
+    if not access:
+        return
+
+    access.has_alerted = True
+    db.commit()
+    db.refresh(access)
+
+
+def get_unalerted_outside_access(db: Session, target_id: int):
+    """未通知の外出中のアクセスを取得"""
+    return (
+        db.query(models.Access)
+        .filter(
+            models.Access.target_id == target_id,
+            models.Access.has_alerted == False,
+            models.Access.come_at == None
+        )
+        .order_by(models.Access.gone_at.desc())
+        .first()
+    )
+
+
+def update_curfew_return(db: Session, target_id: int) -> bool:
+    """
+    門限通知済みで未帰宅の最新レコードを探し、
+    見つかれば come_at を現在時刻で更新する。
+    戻り値: 更新できたら True, 見つからなければ False
+    """
+    access = (
+        db.query(models.Access)
+        .filter(
+            models.Access.target_id == target_id,
+            models.Access.come_at == None,
+            models.Access.has_alerted == True,
+        )
+        .order_by(models.Access.gone_at.desc())
+        .first()
+    )
+
+    if not access:
+        return False
+
+    access.come_at = datetime.now()
+    db.commit()
+    db.refresh(access)
+    return True

--- a/app/services/line_message_service.py
+++ b/app/services/line_message_service.py
@@ -43,7 +43,7 @@ def push_confirm_template(user_id: str, text: str):
     指定ユーザーに門限用確認テンプレートを送信する
     """
     template = ConfirmTemplate(
-        text="門限を過ぎました。\nすでに帰宅していますか？",
+        text=text,
         actions=[
             PostbackAction(label="はい", data="confirm=yes"),
             PostbackAction(label="いいえ", data="confirm=no")
@@ -52,7 +52,7 @@ def push_confirm_template(user_id: str, text: str):
     message = TemplateSendMessage(alt_text=text, template=template)
     
     try:
-        push_message(user_id, message)
+        line_bot_api.push_message(user_id, message)
         print(f"ConfirmTemplate を {user_id} に送信")
     except Exception as e:
         print(f"送信エラー: {e}")


### PR DESCRIPTION
> [!WARNING]
> - **夜またぎ外出の扱い**
>   - 「前日から翌日にかかる外出」の場合、どのタイミングで門限判定を行うかの仕様を決定する必要がある。 

## ■ 門限判定スケジューラの実装
- スケジューラはアプリの立ち上げ時に起動され、門限が未設定の場合は起動しない。
- 門限の時刻（分刻み）をトリガーに1度だけ実行される。

> [!NOTE]
> ### 門限判定処理の流れ
>
> 1. **門限時刻の取得**  
>    - DBから対象者の `curfew_time` を取得する。  
>    - 未設定の場合は処理を終了する。  
>
> 2. **現在時刻との比較**  
>    - `now >= curfew_time` なら「門限超過」と判定する。  
>    - まだ時間前なら何もせず終了。  
>
> 3. **外出中レコードの取得**  
>    - `get_unalerted_outside_access()` を利用して、  
>      - 対象者のレコードのうち  
>        - `come_at IS NULL`（まだ帰宅していない）  
>        - `has_alerted = False`（未通知）  
>      - の条件を満たす最新の外出記録を検索する。 
>
>4. **通知送信**  
>    - 対象レコードが存在する場合、LINE に確認テンプレートを送信する。  
>    - LINE 確認テンプレートは以下のような内容で送られる：  
>      - 「門限を過ぎています。すでに帰宅していますか？」の文章  
>      - ユーザーの応答（「はい／いいえ」）を待つボタン
>
>5. **状態更新**  
>    - 外出レコードを `has_alerted = True` に更新する。  
>    - 対象者の状態を `awaiting_curfew_time` に更新する。

> [!NOTE]
> ### LINE確認テンプレートの応答処理
>   - ユーザー（awaiting_curfew_time状態）が回答した後に行う処理は以下の通り：  
>     1. 「はい（confirm=yes）」の場合  
>        - 対象者のレコードのうち
>          - `come_at IS NULL`（まだ帰宅していない） 
>          - `has_alerted = True`（通知済み） 
>        - の最新の`come_at` に現在時刻を登録 → 帰宅済みにする  
>     2. 「いいえ（confirm=no）」の場合  
>        - 継続して未帰宅扱い

> [!TIP]
> ###  スケジューラ更新の挙動と門限登録時の処理  
>   - 門限時刻を更新した場合、既存のスケジュールジョブは `replace_existing=True` によって置き換えられる。  
>   - つまり、門限を更新すると同時にスケジューラのジョブも最新の時刻に自動で更新される。