### PR TITLE
add:/noticesの追加,update:/touchの変更

### DIFF
--- a/app/routers/device.py
+++ b/app/routers/device.py
@@ -104,7 +104,10 @@ def get_device_notices(db: Session = Depends(get_db)):
 @router.patch("/touch")
 def patch_device_touch(db: Session = Depends(get_db)):
     # 未読メッセージの取得
-    unread_messages = db.query(Message).filter(Message.read_at.is_(None)).all()
+    unread_messages = (
+        db.query(Message)
+        .filter(Message.target_id == TARGET_ID, Message.read_at.is_(None))
+        .all())
 
     if not unread_messages:
         return {"messages": []}

--- a/app/routers/device.py
+++ b/app/routers/device.py
@@ -101,8 +101,8 @@ def get_device_notices(db: Session = Depends(get_db)):
     return {"has_unread": has_unread}
 
 
-@router.post("/touch")
-def post_device_touch(db: Session = Depends(get_db)):
+@router.patch("/touch")
+def patch_device_touch(db: Session = Depends(get_db)):
     # 未読メッセージの取得
     unread_messages = db.query(Message).filter(Message.read_at.is_(None)).all()
 

--- a/app/routers/device.py
+++ b/app/routers/device.py
@@ -43,7 +43,7 @@ def post_device_messages(db: Session = Depends(get_db)):
             # 直近のAccessの参照
             last_access = (
                 db.query(Access)
-                .filter(Access.come_at.is_(None))
+                .filter(Access.target_id == TARGET_ID, Access.come_at.is_(None))
                 .order_by(Access.gone_at.desc())
                 .first()
             )

--- a/app/routers/device.py
+++ b/app/routers/device.py
@@ -91,7 +91,7 @@ def get_device_notices(db: Session = Depends(get_db)):
     # read_at が NULL の最新メッセージを取得
     message = (
         db.query(Message)
-        .filter(Message.target_id == TARGET_ID, Message.read_at == None)
+        .filter(Message.target_id == TARGET_ID, Message.read_at.is_(None))
         .order_by(Message.created_at.desc())
         .first()
     )

--- a/app/routers/device.py
+++ b/app/routers/device.py
@@ -93,14 +93,7 @@ def post_device_touch(db: Session = Depends(get_db)):
 
     # レスポンス用のデータ
     response_data = [
-        {
-            "id": msg.id,
-            "target_id": msg.target_id,
-            "content": msg.content,
-            "read_at": msg.read_at,
-            "created_at": msg.created_at,
-            "updated_at": msg.updated_at,
-        }
+        {"content": msg.content}
         for msg in unread_messages
     ]
 

--- a/app/routers/device.py
+++ b/app/routers/device.py
@@ -83,6 +83,24 @@ def post_device_audio_data(data: dict, db: Session = Depends(get_db)):
     return {"message": "Audio data appended", "samples_received": len(audio_data)}
 
 
+@router.get("/notices")
+def get_device_notices(db: Session = Depends(get_db)):
+    """
+    デバイスに未読メッセージがあるか確認して返すAPI
+    """
+    # read_at が NULL の最新メッセージを取得
+    message = (
+        db.query(Message)
+        .filter(Message.target_id == TARGET_ID, Message.read_at == None)
+        .order_by(Message.created_at.desc())
+        .first()
+    )
+
+    has_unread = message is not None
+
+    return {"has_unread": has_unread}
+
+
 @router.post("/touch")
 def post_device_touch(db: Session = Depends(get_db)):
     # 未読メッセージの取得


### PR DESCRIPTION
## ■ `/notices`の追加（`GET /api/device/notices`）
- デバイスに未読メッセージがあるか確認して返すAPI。
- `read_at` が `NULL` の最新メッセージを取得し、存在するならば`true`、そうでなければ`false`を返す。

**Request**
```json
 {}
 ```
**Response**
 ```json
 {"has_unread": true}
```
## ■ `/touch`の変更
-  `patch`メソッドに変更
   - `POST /api/device/touch` → `PATCH /api/device/touch`

- DB取得に`target_id`を指定

- レスポンス内容を変更

**Response**
```json
 {
    "messages": [
        {"content": "宿題終わった？"}
      ]
  }
```

## ■ `/messages`の変更
- 帰宅時の`come_at`を保存する処理に`target_id`を指定